### PR TITLE
Fix some minimal issues:

### DIFF
--- a/src/API/get_vector.jl
+++ b/src/API/get_vector.jl
@@ -1,11 +1,17 @@
 function get_vector(vecname)
-    vec  = n.ngGet_Vec_Info(vecname)
-    vec != convert(Ptr{Nothing}, 0) || throw("Points to null")
-    vname  = unsafe_load(convert(Ptr{UInt8}, vec.name))
-    vreal  = unsafe_load(vec.realdata)
-    _cmp = unsafe_load(vec.compdata)
-    vcmplx = Complex(_cmp.real, _cmp.imag)
-    return vname, vreal, vcmplx
+    vec = ngGet_Vec_Info(vecname)
+    vec != C_NULL || throw("Vector $(vecname) not found")
+    vecinfo = unsafe_load(vec)
+    vname  = unsafe_string(vecinfo.name)
+    if (vecinfo.flags & VF_REAL) != 0
+        vreal = copy(unsafe_wrap(Array, vecinfo.realdata, (vecinfo.length,)))
+        return vname, vreal
+    elseif (vecinfo.flags & VF_COMPLEX) != 0
+        vcomplex = copy(unsafe_wrap(Array, vecinfo.realdata, (vecinfo.length,)))
+        return vname, vcmplx
+    else
+        error("Unknown vector type")
+    end
 end
 
 #=

--- a/src/interface/ngspice_api.jl
+++ b/src/interface/ngspice_api.jl
@@ -1,22 +1,22 @@
 function ngSpice_Init(printfcn, statfcn, ngexit, sdata, sinitdata, bgtrun, userData)
-    ccall((:ngSpice_Init, libngspice), Cint, (Ptr{SendChar}, Ptr{SendStat}, Ptr{ControlledExit}, Ptr{SendData}, Ptr{SendInitData}, Ptr{BGThreadRunning}, Ptr{Cvoid}), printfcn, statfcn, ngexit, sdata, sinitdata, bgtrun, userData)
+    ccall((:ngSpice_Init, libngspice), Cint, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}), printfcn, statfcn, ngexit, sdata, sinitdata, bgtrun, userData)
 end
 
 function ngSpice_Init_Sync(vsrcdat, isrcdat, syncdat, ident, userData)
-    ccall((:ngSpice_Init_Sync, libngspice), Cint, (Ptr{GetVSRCData}, Ptr{GetISRCData}, Ptr{GetSyncData}, Ptr{Cint}, Ptr{Cvoid}), vsrcdat, isrcdat, syncdat, ident, userData)
+    ccall((:ngSpice_Init_Sync, libngspice), Cint, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cint}, Ptr{Cvoid}), vsrcdat, isrcdat, syncdat, ident, userData)
 end #Julia crashes
 
 function ngSpice_Command(command)
     ccall((:ngSpice_Command, libngspice), Cint, (Cstring,), command)
-end 
+end
 
 function ngGet_Vec_Info(vecname)
-    ccall((:ngGet_Vec_Info, libngspice), vector_info, (Cstring,), vecname)
-end 
+    ccall((:ngGet_Vec_Info, libngspice), pvector_info, (Cstring,), vecname)
+end
 
 function ngSpice_Circ(circarray)
     ccall((:ngSpice_Circ, libngspice), Cint, (Ptr{Ptr{UInt8}},), circarray)
-end #unsafe_convert between ::Type{Ptr{Cstring}}, ::Type{Ptr{String}} needs to be added 
+end #unsafe_convert between ::Type{Ptr{Cstring}}, ::Type{Ptr{String}} needs to be added
 
 function ngSpice_CurPlot()
     ccall((:ngSpice_CurPlot, libngspice), Ptr{UInt8}, ())
@@ -24,10 +24,10 @@ end
 
 function ngSpice_AllPlots()
     ccall((:ngSpice_AllPlots, libngspice), Ptr{Ptr{UInt8}}, ())
-end 
+end
 
 function ngSpice_AllVecs(plotname)
-    ccall((:ngSpice_AllVecs, libngspice), Ptr{UInt8}, (Cstring,), plotname)
+    ccall((:ngSpice_AllVecs, libngspice), Ptr{Cstring}, (Cstring,), plotname)
 end
 
 function ngSpice_running()

--- a/src/interface/ngspice_common.jl
+++ b/src/interface/ngspice_common.jl
@@ -1,10 +1,14 @@
 # Skipping MacroDefinition: IMPEXP __declspec ( dllimport )
-struct ngcomplex
-    real::Cdouble
-    imag::Cdouble
-end
+const ngcomplex_t = Complex{Cdouble}
 
-const ngcomplex_t = ngcomplex
+const VF_REAL = (1 << 0)
+const VF_COMPLEX = (1 << 1)
+const VF_ACCUM = (1 << 2)
+const VF_PLOT = (1 << 3)
+const VF_PRINT = (1 << 4)
+const VF_MINGIVEN = (1 << 5)
+const VF_MAXGIVEN = (1 << 6)
+const VF_PERMANENT = (1 << 7)
 
 struct vector_info
     name::Cstring
@@ -71,16 +75,6 @@ BGThreadRunning typedef of callback function for sending a boolean signal (true 
                 is running)
 =#
 
-const SendChar = Cvoid
-const SendStat = Cvoid
-const ControlledExit  = Cvoid
-const SendData     = Cvoid
-const SendInitData = Cvoid
-const BGThreadRunning = Cvoid
-const GetVSRCData  = Cvoid
-const GetISRCData  = Cvoid
-const GetSyncData = Cvoid
-
 const FnTypeSignatures = Dict(
     :SendChar        => (:Cint, :((Ptr{Char}, Cint, Ptr{Cvoid}))),
     :SendStat        => (:Cint, :((Ptr{Char}, Cint, Ptr{Cvoid}))),
@@ -93,33 +87,33 @@ const FnTypeSignatures = Dict(
     :GetSyncData     => (:Cint, :((Cdouble, Ptr{Cdouble}, Cdouble, Cint, Cint, Cint, Ptr{Cvoid})))
 )
 
-SendChar_wrapper(fp::SendChar) = fp
+SendChar_wrapper(fp::Ptr{Cvoid}) = fp
 SendChar_wrapper(f) = @cfunction($f, Cint, (Ptr{Char}, Cint, Ptr{Cvoid})).ptr
 
-SendStat_wrapper(fp::SendStat) = fp
+SendStat_wrapper(fp::Ptr{Cvoid}) = fp
 SendStat_wrapper(f) = @cfunction($f, Cint, (Ptr{Char}, Cint, Ptr{Cvoid})).ptr
- 
-ContolledExit_wrapper(fp::ControlledExit) = fp
+
+ContolledExit_wrapper(fp::Ptr{Cvoid}) = fp
 ContolledExit_wrapper(f) = @cfunction($f, Cint, (Cint, Cint, Cint, Cint, Ptr{Cvoid})).ptr
 
-SendData_wrapper(fp::SendData) = fp
+SendData_wrapper(fp::Ptr{Cvoid}) = fp
 SendData_wrapper(f) = @cfunction($f, Cint, (Ptr{vecvaluesall}, Cint, Cint, Ptr{Cvoid})).ptr
 
-SendInitData_wrapper(fp::SendInitData) = fp
+SendInitData_wrapper(fp::Ptr{Cvoid}) = fp
 SendInitData_wrapper(f) = @cfunction($f, Cint, (Ptr{vecinfoall}, Cint, Ptr{Cvoid})).ptr
 
-BGThreadRunning_wrapper(fp::BGThreadRunning) = fp
+BGThreadRunning_wrapper(fp::Ptr{Cvoid}) = fp
 BGThreadRunning_wrapper(f) = @cfunction($f, Cint, (Cint, Cint, Ptr{Cvoid})).ptr
 
-GetVSRCData_wrapper(fp::GetVSRCData) = fp
+GetVSRCData_wrapper(fp::Ptr{Cvoid}) = fp
 GetVSRCData_wrapper(f) = @cfunction($f, Cint, (Ptr{Cdouble}, Cdouble, Ptr{Cchar}, Cint, Ptr{Cvoid})).ptr
 
 
-GetISRCData_wrapper(fp::GetISRCData) = fp
+GetISRCData_wrapper(fp::Ptr{Cvoid}) = fp
 GetISRCData_wrapper(f) = @cfunction($f, Cint, (Ptr{Cdouble}, Cdouble, Ptr{Cchar}, Cint, Ptr{Cvoid})).ptr
 
 
-GetSyncData_wrapper(fp::GetSyncData) = fp
+GetSyncData_wrapper(fp::Ptr{Cvoid}) = fp
 GetSyncData_wrapper(f) = @cfunction($f, Cint, (Cdouble, Ptr{Cdouble}, Cdouble, Cint, Cint, Cint, Ptr{Cvoid})).ptr
 
 function SendChar(text::String, id::Int32, userdata)
@@ -129,7 +123,7 @@ end
 sendchar = @cfunction($SendChar, Cint, (Cstring, Cint, Ptr{Cvoid}))
 
 function SendStat(text::String, id::Int32, userdata)
-   
+
     println("SPICE : $text" )
     return 0
 end

--- a/tutorials/ac.jl
+++ b/tutorials/ac.jl
@@ -1,7 +1,6 @@
 #This simulates the ac_ascii file
 
-joinpath(@__DIR__, "..", "src/Ngspice.jl") |> normpath |> include
-n = Ngspice
+import Ngspice as n
 netpath = joinpath(@__DIR__, "..", "inputs/RC2.net") |> normpath
 
 n.load_netlist(netpath)


### PR DESCRIPTION
1. Correct types in the signature of the ngspice API
2. Don't define the callbacks as aliases to `Cvoid`.
	Doing so will not create a new type, but rather alias the Cvoid (Nothing) type,
	so e.g. function SendChar(...) was the same as (::Nothing)(...). Needless to say,
        adding new constructors to `Nothing` is a bad idea. You can do what you want here,
        by defining a struct like `struct SendChar; end`, to give it identity, but just
	plain `Cvoid` will work fine.