### PR TITLE
Fix ngspice printing functions

### DIFF
--- a/src/API/running.jl
+++ b/src/API/running.jl
@@ -1,8 +1,11 @@
 cmd(command) = ngSpice_Command(command) #should typeof(command) be restricted
 
-init()      = (pvoid = convert(Ptr{Nothing}, 0); 
-                ngSpice_Init(psendchar, psendstat, pcontrolledexit, 
-                psenddata, psendinitdata, pbgthread, pvoid))
+init()      = (pvoid = convert(Ptr{Nothing}, 0);
+                ngSpice_Init(gen_psendchar(), gen_psendstat(),
+                gen_pcontrolledexit(),
+                gen_psenddata(),
+                gen_psendinitdata(),
+                gen_pbgthread(), pvoid))
 
 # isrunning() = ngSpice_running() # always returns 0
 
@@ -12,7 +15,7 @@ bgrun()   = cmd("bg_run")
 set_breakpoint(bkpt::Float64) = ngSpice_SetBkpt(bkpt)
 
 stop()    = cmd("stop")
-bghalt()  = cmd("bg_halt") 
+bghalt()  = cmd("bg_halt")
 
 reset()   = cmd("reset")
 resume()  = cmd("resume")

--- a/src/NgSpice.jl
+++ b/src/NgSpice.jl
@@ -13,11 +13,11 @@ include("interface/ngspice_common.jl")
 include("interface/ngspice_api.jl")
 
 #= Might not be necessary
-export bgthreadrunning, controlledexit, #getISRCdata, detsyncdata, getVSRCdata, 
+export bgthreadrunning, controlledexit, #getISRCdata, detsyncdata, getVSRCdata,
        sendchar, senddata, sendstat, sendinitdata=#
 
 export gen_pbgthread, gen_pcontrolledexit, gen_psendchar, gen_psenddata,
-       gen_psendinitdata, gen_psendstat, 
+       gen_psendinitdata, gen_psendstat,
        pbgthread, pcontrolledexit, psendchar, psenddata, psendinitdata,
        psendstat
 

--- a/src/interface/ngspice_common.jl
+++ b/src/interface/ngspice_common.jl
@@ -29,7 +29,7 @@ end
 const pvector_info = Ptr{vector_info}
 
 struct vecvalues
-    name::Cstring              # name of a specific vector 
+    name::Cstring              # name of a specific vector
     creal::Cdouble             # actual data value
     cimag::Cdouble             # actual data value
     is_scale::Cint             # if 'name' is the scale vector
@@ -41,14 +41,14 @@ const pvecvalues = Ptr{vecvalues}
 struct vecvaluesall
     veccount::Cint         # number of vectors in plot
     vecindex::Cint         # index of actual set of vectors. i.e. the number of accepted data point
-    vecsa::pvecvalues # values of actual set of vectors, indexed from 0 to veccount - 1 
+    vecsa::pvecvalues # values of actual set of vectors, indexed from 0 to veccount - 1
         #just pvecvalues?
 end
 
 const pvecvaluesall = Ptr{vecvaluesall}
-struct vecinfo              
+struct vecinfo
     number::Cint           # number of vector, as postion in the linked list of vectors, s
-    name::Cstring          # name of the actual vector 
+    name::Cstring          # name of the actual vector
     is_real::Cint          # 1 if the actual vector has real data
     pdvec::Ptr{Cvoid}      # a void pointer to struct dvec *d, the actual vector
     pdvecscale::Ptr{Cvoid} # a void pointer to struct dvec *ds, the scale vector
@@ -63,7 +63,7 @@ struct vecinfoall
     date::Cstring
     type::Cstring
     veccount::Cint
-    vecs::pvecinfo 
+    vecs::pvecinfo
 end
 
 #const pvecinfoall = Ptr{vecinfoall}
@@ -74,7 +74,7 @@ function sendchar(_text::Ptr{Cchar}, id::Cint, userdata)::Cint
     _text != C_NULL || throw("Not a valid text")
     text = unsafe_string(_text)
     println(text)
-    # write the `text` to a log file as it isn't `print`ed to the REPL 
+    # write the `text` to a log file as it isn't `print`ed to the REPL
     # in a non-native environment
     open("log_$(Dates.format(now(), "yyyy_mm_ddTHH")).txt", "a") do f
         write(f, "$(Dates.format(now(), "MM:SS")): "*text*"\n")
@@ -83,14 +83,13 @@ function sendchar(_text::Ptr{Cchar}, id::Cint, userdata)::Cint
     return 0
 end
 
-gen_psendchar() = @cfunction($sendchar, Cint, (Ptr{Cchar}, Cint, Ptr{Cvoid}))
-psendchar       = gen_psendchar()
+gen_psendchar() = @cfunction(sendchar, Cint, (Ptr{Cchar}, Cint, Ptr{Cvoid}))
 
 function sendstat(_text::Ptr{Cchar}, id::Cint, userdata)::Cint
     _text != C_NULL || throw("Not a valid text")
     text = unsafe_string(_text)
     println(text)
-    # write the `text` to a log file as it isn't `print`ed to the REPL 
+    # write the `text` to a log file as it isn't `print`ed to the REPL
     # in a non-native environment
     open("log_$(Dates.format(now(), "yyyy_mm_ddTHH")).txt", "a") do f
         write(f, "$(Dates.format(now(), "MM:SS")): "*text*"\n")
@@ -98,20 +97,18 @@ function sendstat(_text::Ptr{Cchar}, id::Cint, userdata)::Cint
     return 0
 end
 
-gen_psendstat() = @cfunction($sendstat, Cint, (Ptr{Cchar}, Cint, Ptr{Cvoid}))
-psendstat       = gen_psendstat()
+gen_psendstat() = @cfunction(sendstat, Cint, (Ptr{Cchar}, Cint, Ptr{Cvoid}))
 
 function bgthreadrunning(run::Cint, id::Cint, userdata::Ptr{Cvoid})::Cint
     bgrunning = run
-    run ? println("BG thread is not running") : 
+    run ? println("BG thread is not running") :
         println("BG thread is running")
     return 0
 end
 
-gen_pbgthread() = @cfunction($bgthreadrunning, Cint, (Cint, Cint, Ptr{Cvoid}))
-pbgthread       = gen_pbgthread()
+gen_pbgthread() = @cfunction(bgthreadrunning, Cint, (Cint, Cint, Ptr{Cvoid}))
 
-function controlledexit(exitstatus::Cint, immediate::Cint, 
+function controlledexit(exitstatus::Cint, immediate::Cint,
     quitexit::Cint, id::Cint, userdata::Ptr{Cvoid})::Cint
     quitexit == 1 && println("Returned from quit with exit status")
     immediate == 1 ? (println("Unloading NgSpice"); ngSpice_Command("quit")) :
@@ -119,22 +116,20 @@ function controlledexit(exitstatus::Cint, immediate::Cint,
     return exitstatus
 end
 
-gen_pcontrolledexit() = @cfunction($controlledexit, Cint, (Cint, Cint, Cint, Cint, Ptr{Cvoid}))
-pcontrolledexit       = gen_pcontrolledexit() 
+gen_pcontrolledexit() = @cfunction(controlledexit, Cint, (Cint, Cint, Cint, Cint, Ptr{Cvoid}))
 
 function senddata(vecdata::Ptr{vecinfoall},
     id::Cint, userdata::Ptr{Cvoid})::Cint
     return 0
 end
 
-gen_psenddata() = @cfunction($senddata, Cint, (Ptr{vecinfoall}, Cint, Ptr{Cvoid}))
-psenddata       = gen_psenddata() 
+gen_psenddata() = @cfunction(senddata, Cint, (Ptr{vecinfoall}, Cint, Ptr{Cvoid}))
 
 function sendinitdata(initdata::Ptr{vecinfoall}, id::Cint, userdata::Ptr{Cvoid})
     #=
-    This bit is problematic because it always returns C_NULLs even before 
+    This bit is problematic because it always returns C_NULLs even before
     `data.veccount` number of `vecinfo`s are passed.
-    Even when that is handled it's o/p is always `nothing` 
+    Even when that is handled it's o/p is always `nothing`
     and array of `nothing`s
 
     initdata == C_NULL && throw("No initialized data")
@@ -151,5 +146,4 @@ function sendinitdata(initdata::Ptr{vecinfoall}, id::Cint, userdata::Ptr{Cvoid})
     return zero(Int32)
 end
 
-gen_psendinitdata() = @cfunction($sendinitdata, Cint, (Ptr{vecinfoall}, Cint, Ptr{Cvoid}))
-psendinitdata       = gen_psendinitdata() 
+gen_psendinitdata() = @cfunction(sendinitdata, Cint, (Ptr{vecinfoall}, Cint, Ptr{Cvoid}))


### PR DESCRIPTION
The current approach doesn't work, because it generates the pointers
once, which doesn't survive precompilation - instead generate the pointers
on init.

Also fix some whitespace while I'm here