### PR TITLE
Comment `Plots` in the tests and add explanation of ngspice-`plot`

### DIFF
--- a/src/API/graphs.jl
+++ b/src/API/graphs.jl
@@ -6,30 +6,15 @@ struct NgSpiceGraphs end
 
 const graph = NgSpiceGraphs()
 
-@recipe function ng(::NgSpiceGraphs, fort, veclist, title, xlims=nothing)
-    ft = getrealvec(fort)
-    legend := true
-    grid := true
-    title := "$title"
-    background_color --> Colors.RGB(0.0, 0.0, 0.0)
-    xguide := fort
-    guide := String.(veclist)
-    color_palette --> :default
-    seriestype := :path
-    overwrite_figure := false
-    vec = getrealvec.(veclist)
-    #isa(xlims, Nothing) || xlims := xlims
-    ft, vec
-end
-
+# `fort` is frequency or time vector. It is the `X` axis and should always be real.
 @recipe function ng(::NgSpiceGraphs, vectype, fort, veclist, title, xlims=nothing)
     ft = getrealvec(fort)
-    legend := true
+    label := permutedims(veclist)
     grid := true
     title := "$title"
     background_color --> Colors.RGB(0.0, 0.0, 0.0)
     xguide := fort
-    guide := String.(veclist)
+    guide := length(veclist) > 1 ? "signals" : "signal"
     color_palette --> :default
     seriestype := :path
     overwrite_figure := false

--- a/tutorials/mosfet.jl
+++ b/tutorials/mosfet.jl
@@ -1,5 +1,5 @@
 using NgSpice
-using Plots
+# using Plots
 n = NgSpice
 
 netpath = joinpath(@__DIR__, "..", "inputs", "mosfet.cir") |> normpath
@@ -11,10 +11,11 @@ n.display()        # Returns a dataframe of current vectors
 n.listallvecs()    # Lists vectors of both active and inactive plots
 n.curplot()        # Current active plot
 n.listcurvecs()    # Vectors in current active plot
-# Vector type can be specified by sending it as a parameter
-# plot(n.graph, n.getimagvec, "time", ["emit", "vcc"], "Title of the plot")
-sweep = n.getvec("time")[end]   # Returns vector info of `time` vector 
-emit = n.getvec("emit")[end]   # Returns vector info of `emit` vector 
-vcc = n.getvec("vcc")[end]   # Returns vector info of `vcc` vector 
-plot(sweep, [emit vcc], label=["emit" "vcc"], title="Title of the plot")
-n.exit()           # Runs "unset askquit" of Ngspice
+
+# For plotting the signals, pass `n.graph` an object of `NgSpiceGraphs` type.
+# And then, specify the get-vector method.
+# Pass "time" or "frequency"
+# List of signals to plot
+# Finally, the title of the plot
+# plot(n.graph, n.getimagvec, "time", ["emit", "vcc"], "Simple MOSFET")
+# plot(n.graph, n.getrealvec, "time", ["emit", "vcc"], "Simple MOSFET")


### PR DESCRIPTION
- I'm commenting out all plotting functions so that `Pkg.test()` will work even without `Plots`
---

- There wasn't any error with ngspice's plot-recipe . The particular example was plotting out the _imaginary_ part of the vectors which was 0. It was to demonstrate that vectors can be fetched in modes other than real.
- Now I have added an explanation and a real vector example too.
---

- Also, I noticed `guide` on the `Y` axis was printing out the y vector list. I've changed it to `signals` instead. 
- And recipe which doesn't need `get<type>vector` as a parameter is removed.