### PR TITLE
Auto-initialize NgSpice to avoid segfaults

### DIFF
--- a/src/NgSpice.jl
+++ b/src/NgSpice.jl
@@ -33,6 +33,11 @@ include("API/running.jl")
 function __init__()
     @require Plots="91a5bcdd-55d7-5caf-9e0b-520d859cae80" @eval include("API/repl.jl")
     @require Plots="91a5bcdd-55d7-5caf-9e0b-520d859cae80" @eval include("API/graphs.jl")
+
+    # Ensure that NgSpice is initialized, as otherwise it's easy to get segfaults
+    # because NgSpice expects a printf callback to be provided (as we do in the
+    # init() method we're calling here)
+    init()
 end
 
 export get_vector_info,


### PR DESCRIPTION
Ironically, NgSpice is attempting to print out that you should call `NgSpice_init()`, so that you can provide a print callback, but because you haven't called `NgSpice_init()`, the print callback is NULL, and we segfault.