### PR TITLE
Added a wrapper for the ngspice alter command

### DIFF
--- a/src/API/running.jl
+++ b/src/API/running.jl
@@ -28,5 +28,7 @@ bghalt()  = (println("Halting the simulator in a background thread");
 reset()   = (println("Resetting the simulator"); cmd("reset"))
 resume()  = (println("Resuming the simulator"); cmd("resume"))
 
+alter(command::String) = cmd(string("alter ", command))
+
 quit()    = cmd("quit")
 exit()    = (println("Quitting immediately"); cmd("unset askquit"); cmd("quit"))

--- a/src/NgSpice.jl
+++ b/src/NgSpice.jl
@@ -46,6 +46,6 @@ export get_vector_info,
        NgSpiceGraphs, graph,
        load_netlist, source, source_sp,
        bghalt, bgrun, cmd, init,
-       interactive
+       interactive, alter
        #isrunning,
 end


### PR DESCRIPTION
I added a wrapper for the ngspice `alter` command in `running.jl`, and exported the function in `NgSpice.jl`.  I wanted to use `alter` in my code, and this seemed like a good way to do it.